### PR TITLE
修复测试用例InstanceMethod2中值类型和引用类型参数混用导致的错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ var msg=new SolidClass().Run("Hello World!");
 
 ## 普通方法Hook
 
-静态和非静态的普通方法Hook操作都是一模一样的，两步到位：新建一个类实现`IMethodHook`接口，编写普通Hook方法，用`HookMethod`特性标记此方法，有无static修饰、返回值类型不同都不影响，但参数签名要和被Hook的原始方法一致。
+静态和非静态的普通方法Hook操作都是一模一样的，两步到位：新建一个类实现`IMethodHook`接口，编写普通Hook方法，用`HookMethod`特性标记此方法，有无static修饰、返回值类型（仅针对引用性质的类型，非int等值类型）不同都不影响，但参数签名要和被Hook的原始方法一致，值类型和引用类型尽量不要混用。
 
 
 ### 第一步：新建一个类实现`IMethodHook`接口
@@ -88,7 +88,7 @@ public string MyMethod(string param){...}
 ### 注意：方法参数
 参数签名要和被Hook的原始方法一致，如果不一致将导致无法找到原始方法（原因：存在重载方法无法确认是哪个的问题）。
 
-如果存在我们无法使用的参数类型的时候（如：私有类型），我们可以用object等其他类型代替此类型，并把此参数用`RememberType`进行标记：
+如果存在我们无法使用的参数类型的时候（如：私有类型），我们可以用object等其他引用类型代替此类型（注意不要用值类型，否则可能出现内存访问错误），并把此参数用`RememberType`进行标记：
 ``` C#
 //目标方法:
 public string SolidMethod(MyClass data, int code){...}

--- a/Test/MonitorTest.cs
+++ b/Test/MonitorTest.cs
@@ -83,7 +83,8 @@ namespace Test
 
             Assert.AreEqual("Hook<int> 123", Computer.Any<int>(123));
             //引用类型的没法正确hook，不知道啥原因
-            //Assert.AreEqual("Hook<string> str", Computer.Any<string>("str"));
+            Assert.AreEqual("Not HooK str", "Not HooK " + Computer.Any<string>("str"));
+            Console.WriteLine("引用类型泛型参数的泛型方法无法被hook");
 
 
             //注意：存在SynchronizationContext时(如：HttpContext)，异步方法不能直接在同步方法中调用，真发生异步行为时100%死锁

--- a/Test/MonitorTest.cs
+++ b/Test/MonitorTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Runtime.Remoting.Messaging;
 using System.Threading.Tasks;
 using System.Threading;
+using System.Text;
 
 namespace Test
 {
@@ -51,7 +52,9 @@ namespace Test
         [TestMethod]
         public void InstanceMethod2() {
             MethodHook.Install();
-            Assert.AreEqual("Hook 土豆(worked)", new Computer().Work("土豆"));
+            Assert.AreEqual("Hook 土豆(String worked)", new Computer().Work("土豆"));
+            Assert.AreEqual("Hook 9527(Int32 worked)", new Computer().Work(9527));
+            Assert.AreEqual(123456053L, new Computer().Work(new StringBuilder("aaa")));
 
             //注意：存在SynchronizationContext时(如：HttpContext)，异步方法不能直接在同步方法中调用，真发生异步行为时100%死锁
             var bak = SynchronizationContext.Current;

--- a/Test/Samples.cs
+++ b/Test/Samples.cs
@@ -35,7 +35,13 @@ namespace Test
             }
         }
         public string Work(string msg) {
-            return msg + "(worked)";
+            return msg + "(" + msg.GetType().Name + " worked)";
+        }
+        public string Work(int msg) {
+            return msg + "(" + msg.GetType().Name + " worked)";
+        }
+        public int Work(StringBuilder msg) {
+            return 123456000+ msg.Length;
         }
         public async Task<string> WorkAsync(string msg) {
             await Task.Delay(1);
@@ -135,16 +141,32 @@ namespace Test
 
         #region 实例方法（不实现OriginalMethod、方法名称和原方法名称不同）
         [HookMethod(typeof(Computer), "Work", "WorkFn")]
-        public string XXXWork([RememberType("System.String")]int msg) {
-            return "Hook "+WorkFn(msg);
+        public string XXXWork([RememberType("System.String")]object msg) {
+            return "Hook " + WorkFn(msg);
+        }
+        [HookMethod(typeof(Computer), "Work", "WorkFn")]
+        public string XXXWork([RememberType("System.Int32")]long msg) {
+            return "Hook " + WorkFn(msg);
+        }
+        [HookMethod(typeof(Computer), "Work", "WorkFn")]
+        public long XXXWork([RememberType("System.Text.StringBuilder")]Encoding msg) {
+            return WorkFn(msg)+50;
         }
 
         [OriginalMethod]
-        public object WorkFn(int msg) {//和上面方法参数签名一致即可正确匹配
+        public object WorkFn(long msg) {//注意此处值类型的参数必须也是值类型
             return null;
         }
         [OriginalMethod]
-        public object WorkFn(string msg) {//超级干扰，这个方法是无效的
+        public long WorkFn(Encoding msg) {//注意此处值类型的返回值必须也是值类型，内存长度必须相同或者更大，否则数据必然丢失
+            return 0;
+        }
+        [OriginalMethod]
+        public object WorkFn(object msg) {//和string的签名一致即可正确匹配
+            return null;
+        }
+        [OriginalMethod]
+        public object WorkFn(string msg) {//超级干扰，这个方法没有谁用到了
             return null;
         }
         #endregion

--- a/Test/Samples.cs
+++ b/Test/Samples.cs
@@ -145,7 +145,7 @@ namespace Test
             return "Hook " + WorkFn(msg);
         }
         [HookMethod(typeof(Computer), "Work", "WorkFn")]
-        public string XXXWork([RememberType("System.Int32")]long msg) {
+        public string XXXWork([RememberType("System.Int32")]int msg) {
             return "Hook " + WorkFn(msg);
         }
         [HookMethod(typeof(Computer), "Work", "WorkFn")]
@@ -154,7 +154,7 @@ namespace Test
         }
 
         [OriginalMethod]
-        public object WorkFn(long msg) {//注意此处值类型的参数必须也是值类型
+        public object WorkFn(int msg) {//注意此处值类型的参数必须也是完全一样的值类型
             return null;
         }
         [OriginalMethod]


### PR DESCRIPTION
出问题的地方：
https://github.com/bigbaldy1128/DotNetDetour/blob/8f39119094684300f39768880b32c4971c064d3c/Test/Samples.cs#L137-L138

此处参数是`String`引用类型，但Hook方法使用`int`值类型作为演示，导致两种不同性质的类型混用，从而产生问题。

在vs2017下测试不能通过，把`int`值类型改成其他引用类型后就没有问题了。

顺带增加了几个值类型的参数、返回值的测试。经过测试发现，值类型和引用类型参数、返回值 不能混用，值类型的必须用值性质的类型，引用类型必须用引用性质的类型。

ps：上面提到的各种类型，由于不知道具体的术语叫什么，按字面意思理解吧😜